### PR TITLE
Updates link to metrics section in docs

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -44,7 +44,7 @@
       },
       "id": 42,
       "options": {
-        "content": "# Kyverno\nA Kubernetes-native policy management engine\n\n#### About this dashboard\n\nThis dashboard represents generic insights which can be extracted and made well use of from a cluster with Kyverno in action.\n\n#### For more details around the metrics\n\nCheckout the [official docs of Kyverno metrics](https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/)",
+        "content": "# Kyverno\nA Kubernetes-native policy management engine\n\n#### About this dashboard\n\nThis dashboard represents generic insights which can be extracted and made well use of from a cluster with Kyverno in action.\n\n#### For more details around the metrics\n\nCheckout the [official docs of Kyverno metrics](https://kyverno.io/docs/monitoring/)",
         "mode": "markdown"
       },
       "pluginVersion": "8.1.0",


### PR DESCRIPTION
The current link (https://kyverno.io/docs/monitoring-kyverno-with-prometheus-metrics/) cant be found (Error 404). This pr updates the link to the current metrics page in the docs.