### PR TITLE
Improve Kyverno Dashboard

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -129,13 +129,13 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_policy_results_total{rule_result=\"pass\"})*100/sum(kyverno_policy_results_total{})",
+          "expr": "sum(delta(kyverno_policy_results_total{rule_result=\"fail\"}[24h]))*100/sum(delta(kyverno_policy_results_total{}[24h]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Rule Execution Success Rate",
+      "title": "Rule Execution Failure Rate (Last 24 Hours)",
       "transparent": true,
       "type": "gauge"
     },
@@ -313,13 +313,13 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_policy_results_total{rule_result=\"pass\", policy_background_mode=\"true\"})*100/sum(kyverno_policy_results_total{policy_background_mode=\"true\"})",
+          "expr": "sum(delta(kyverno_policy_results_total{rule_result=\"fail\", policy_background_mode=\"true\"}[24h]))*100/sum(delta(kyverno_policy_results_total{policy_background_mode=\"true\"}[24h]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Background Scans Success Rate",
+      "title": "Background Scans Failure Rate (Last 24 Hours)",
       "transparent": true,
       "type": "gauge"
     },
@@ -572,7 +572,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_policy_results_total{rule_execution_cause=\"admission_request\"}) by (rule_result)",
+          "expr": "sum(delta(kyverno_policy_results_total{rule_execution_cause=\"admission_request\"}[5m])) by (rule_result)",
           "interval": "",
           "legendFormat": "{{rule_result}}",
           "refId": "A"
@@ -678,7 +678,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_policy_results_total{rule_execution_cause=\"background_scan\"}) by (rule_result)",
+          "expr": "sum(delta(kyverno_policy_results_total{rule_execution_cause=\"background_scan\"}[5m])) by (rule_result)",
           "interval": "",
           "legendFormat": "{{rule_result}}",
           "refId": "A"
@@ -785,7 +785,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(sum(kyverno_policy_results_total{rule_result=\"fail\"}) by (policy_name, policy_type)) by (policy_type)",
+          "expr": "sum(sum(delta(kyverno_policy_results_total{rule_result=\"fail\"}[5m])) by (policy_name, policy_type)) by (policy_type)",
           "interval": "",
           "legendFormat": "{{policy_type}}",
           "refId": "A"
@@ -891,7 +891,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(sum(kyverno_policy_results_total{rule_execution_cause=\"admission_request\"}) by (policy_name, rule_result)) by (rule_result)",
+          "expr": "sum(sum(delta(kyverno_policy_results_total{rule_execution_cause=\"admission_request\"}[5m])) by (policy_name, rule_result)) by (rule_result)",
           "interval": "",
           "legendFormat": "{{rule_result}}",
           "refId": "A"
@@ -997,7 +997,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(sum(kyverno_policy_results_total{rule_execution_cause=\"background_scan\"}) by (policy_name, rule_result)) by (rule_result)",
+          "expr": "sum(sum(delta(kyverno_policy_results_total{rule_execution_cause=\"background_scan\"}[5m])) by (policy_name, rule_result)) by (rule_result)",
           "interval": "",
           "legendFormat": "{{rule_result}}",
           "refId": "A"
@@ -1635,7 +1635,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(kyverno_policy_execution_duration_seconds_sum{}) by (rule_type)",
+          "expr": "sum(rate(kyverno_policy_execution_duration_seconds_sum{}[5m])) by (rule_type) / sum(rate(kyverno_policy_execution_duration_seconds_count{}[5m])) by (rule_type)",
           "interval": "",
           "legendFormat": "{{rule_type}}",
           "refId": "A"
@@ -1645,7 +1645,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Average Rule Execution Latency",
+      "title": "Average Rule Execution Latency Over Time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1739,7 +1739,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(sum(kyverno_policy_execution_duration_seconds_sum{}) by (policy_name, policy_type)) by (policy_type)",
+          "expr": "sum(rate(kyverno_policy_execution_duration_seconds_sum{}[5m])) by (policy_type) / sum(rate(kyverno_policy_execution_duration_seconds_count{}[5m])) by (policy_type)",
           "interval": "",
           "legendFormat": "{{policy_type}}",
           "refId": "A"
@@ -1749,7 +1749,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Average Policy Execution Latency",
+      "title": "Average Policy Execution Latency Over Time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1835,7 +1835,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(kyverno_policy_execution_duration_seconds_sum{})",
+          "expr": "sum(kyverno_policy_execution_duration_seconds_sum{}) / sum(kyverno_policy_execution_duration_seconds_count{})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1891,7 +1891,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(sum(kyverno_policy_execution_duration_seconds_sum{}) by (policy_name, policy_type))",
+          "expr": "avg(sum(kyverno_policy_execution_duration_seconds_sum{}) by (policy_name, policy_type) / sum(kyverno_policy_execution_duration_seconds_count{}) by (policy_name, policy_type))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1959,7 +1959,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(kyverno_admission_requests_total{}) by (resource_request_operation)",
+          "expr": "sum(rate(kyverno_admission_review_duration_seconds_sum{}[5m])) by (resource_request_operation) / sum(rate(kyverno_admission_review_duration_seconds_count{}[5m])) by (resource_request_operation)",
           "interval": "",
           "legendFormat": "Resource Operation: {{resource_request_operation}}",
           "refId": "A"
@@ -1969,7 +1969,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Avg - Admission Review Duration (by operation)",
+      "title": "Avg - Admission Review Duration Over Time (by operation)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2054,7 +2054,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_admission_requests_total{}) by (resource_kind)",
+          "expr": "sum(rate(kyverno_admission_review_duration_seconds_sum{}[5m])) by (resource_kind) / sum(rate(kyverno_admission_review_duration_seconds_count{}[5m])) by (resource_kind)",
           "interval": "",
           "legendFormat": "Resource Kind: {{resource_kind}}",
           "refId": "A"
@@ -2064,7 +2064,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Avg - Admission Review Duration (by resource kind)",
+      "title": "Avg - Admission Review Duration Over Time (by resource kind)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2151,13 +2151,13 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(kyverno_admission_requests_total{}[5m]))",
+          "expr": "sum(delta(kyverno_admission_requests_total{}[5m]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Rate - Incoming Admission Requests (last 5m)",
+      "title": "Rate - Incoming Admission Requests (per 5m)",
       "type": "stat"
     },
     {
@@ -2207,7 +2207,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg(kyverno_admission_review_duration_seconds_sum{})",
+          "expr": "sum(kyverno_admission_review_duration_seconds_sum{})/sum(kyverno_admission_review_duration_seconds_count{})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2285,7 +2285,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_policy_changes_total{}) by (policy_change_type)",
+          "expr": "sum(delta(kyverno_policy_changes_total{}[5m])) by (policy_change_type)",
           "interval": "",
           "legendFormat": "Change type: {{policy_change_type}}",
           "refId": "A"
@@ -2295,7 +2295,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Policy Changes (by change type)",
+      "title": "Policy Changes Over Time (by change type)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2389,7 +2389,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_policy_changes_total{}) by (policy_type)",
+          "expr": "sum(delta(kyverno_policy_changes_total{}[5m])) by (policy_type)",
           "interval": "",
           "legendFormat": "{{policy_type}}",
           "refId": "A"
@@ -2399,7 +2399,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Policy Changes (by policy type)",
+      "title": "Policy Changes Over Time (by policy type)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2485,13 +2485,13 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_policy_changes_total{})",
+          "expr": "sum(delta(kyverno_policy_changes_total{}[24h]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Total Policy Changes",
+      "title": "Total Policy Changes (Last 24 Hours)",
       "type": "stat"
     },
     {
@@ -2541,7 +2541,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(kyverno_admission_requests_total{}[5m]))",
+          "expr": "sum(rate(kyverno_policy_changes_total{}[5m]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -2615,7 +2615,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_admission_requests_total{}) by (resource_request_operation)",
+          "expr": "sum(delta(kyverno_admission_requests_total{}[5m])) by (resource_request_operation)",
           "interval": "",
           "legendFormat": "Resource Operation: {{resource_request_operation}}",
           "refId": "A"
@@ -2716,7 +2716,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_admission_requests_total{}) by (resource_kind)",
+          "expr": "sum(delta(kyverno_admission_requests_total{}[5m])) by (resource_kind)",
           "interval": "",
           "legendFormat": "Resource Kind: {{resource_kind}}",
           "refId": "A"
@@ -2813,13 +2813,13 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(kyverno_admission_requests_total{})",
+          "expr": "sum(delta(kyverno_admission_requests_total{}[24h]))",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Total Admission Requests",
+      "title": "Total Admission Requests (Last 24 Hours)",
       "type": "stat"
     }
   ],


### PR DESCRIPTION
Makes the following important changes:

* Fixes places where incorrect metric was used
* Applies `delta` or `rate` to counters to give meaningful data over time rather than unhelpful increasing timeseries
* Properly calculates averages for histogram metrics (divide sum by count; _don't_ use avg)
* Change "Pass Percentage" gauges to "Fail Percentage" -- pass percentage is misleading, since it drops when there are many skips. Fail percentage gives you a clearer picture of what's happening.